### PR TITLE
ISLANDORA-2074: Travis-CI updates on our JAVA test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
 install:
-  - echo "Downloading Maven 3.1";
-  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.1.0-bin.zip || travis_terminate 1
-  - unzip -qq apache-maven-3.1.0-bin.zip || travis_terminate 1
-  - export M2_HOME=$PWD/apache-maven-3.1
+  - echo "Downloading Maven 3.0";
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
+  - export M2_HOME=$PWD/apache-maven-3.0
   - export PATH=$M2_HOME/bin:$PATH
   - mvn -version
   - mvn clean package install -DskipTests -Dgpg.skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ env:
   - FEDORA_VERSION=3.8.1
 install:
   - echo "Downloading Maven 3.1";
-  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.1-bin.zip || travis_terminate 1
-  - unzip -qq apache-maven-3.1-bin.zip || travis_terminate 1
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.1.0-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.1.0-bin.zip || travis_terminate 1
   - export M2_HOME=$PWD/apache-maven-3.1
   - export PATH=$M2_HOME/bin:$PATH
   - mvn -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - FEDORA_VERSION=3.8.1
 matrix:
   allow_failures:
-    - oraclejdk9
+    - jdk: oraclejdk9
 install:
   - echo "Downloading Maven 3.0";
   - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: java
 cache:
   directories:
   - $HOME/.m2
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
 jdk:
   - openjdk6
   - openjdk7
@@ -13,14 +17,7 @@ env:
   - FEDORA_VERSION=3.7.0
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
-install:
-  - echo "Downloading Maven 3.0";
-  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
-  - unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
-  - export M2_HOME=$PWD/apache-maven-3.0
-  - export PATH=$M2_HOME/bin:$PATH
-  - mvn -version
-  - mvn clean package install -DskipTests -Dgpg.skip
+
 script:
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=travis -Ddb.pass=""
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=postgres -Ddb.pass="" -Ddb.port=5432 -Ddb.class="org.postgresql.Driver" -Ddb.scheme="jdbc:postgresql" -Ddb.group=postgresql -Ddb.artifact=postgresql -Ddb.version="9.1-901.jdbc4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: java
 cache:
   directories:
@@ -13,6 +13,14 @@ env:
   - FEDORA_VERSION=3.7.0
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
+install:
+  - echo "Downloading Maven 3.0";
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.0-bin.zip || travis_terminate 1
+  - export M2_HOME=$PWD/apache-maven-3.0
+  - export PATH=$M2_HOME/bin:$PATH
+  - mvn -version
+  - mvn clean package install -DskipTests -Dgpg.skip
 script:
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=travis -Ddb.pass=""
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=postgres -Ddb.pass="" -Ddb.port=5432 -Ddb.class="org.postgresql.Driver" -Ddb.scheme="jdbc:postgresql" -Ddb.group=postgresql -Ddb.artifact=postgresql -Ddb.version="9.1-901.jdbc4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: true
+dist: trusty
+sudo: required
 language: java
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,14 @@ env:
   - FEDORA_VERSION=3.7.0
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
-
+install:
+  - echo "Downloading Maven 3.1";
+  - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.1-bin.zip || travis_terminate 1
+  - unzip -qq apache-maven-3.1-bin.zip || travis_terminate 1
+  - export M2_HOME=$PWD/apache-maven-3.1
+  - export PATH=$M2_HOME/bin:$PATH
+  - mvn -version
+  - mvn clean package install -DskipTests -Dgpg.skip
 script:
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=travis -Ddb.pass=""
   - mvn test -DskipTests=false -Dfedora.version=$FEDORA_VERSION -Ddb.name=drupal_test -Ddb.user=postgres -Ddb.pass="" -Ddb.port=5432 -Ddb.class="org.postgresql.Driver" -Ddb.scheme="jdbc:postgresql" -Ddb.group=postgresql -Ddb.artifact=postgresql -Ddb.version="9.1-901.jdbc4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ addons:
 jdk:
   - openjdk6
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
 env:
   - FEDORA_VERSION=3.6.2
   - FEDORA_VERSION=3.7.0
   - FEDORA_VERSION=3.7.1
   - FEDORA_VERSION=3.8.1
+matrix:
+  allow_failures:
+    - oraclejdk9
 install:
   - echo "Downloading Maven 3.0";
   - wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1


### PR DESCRIPTION
**ISLANDORA-2074**: (https://jira.duraspace.org/browse/ISLANDORA-2074)

http://irclogs.islandora.ca/2017-10-02.html

# What does this Pull Request do?

Changes the way openjdk6 is deployed on Travis-CI, trusty, removes Oracle JDK7 and looking forward, adds Oracle JDK9 (experimental, allowing failures). 

# What's new?

Since September 2017, Ubuntu Trusty became the default Linux image for automated Travis-CI testing. When that happened our tests started failing because of new defaults and also deprecated packages. Also, with the advent of JDK 9, Oracle removed JDK7 binaries from their download site (final-completely) 

# How should this be tested?

This auto-tests. If Travis-CI is green means we have tests passing

# Additional Notes:
If there are compelling reasons to force somehow OracleJDK7 to run by providing some (legal) alternative to the removed binaries, this is the place to speak so.
 
https://github.com/travis-ci/travis-ci/issues/7019
https://github.com/travis-ci/travis-ci/issues/8206
http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html

# Interested parties
@Islandora/7-x-1-x-committers